### PR TITLE
modified tasks view screen and create task screen

### DIFF
--- a/.expo/packager-info.json
+++ b/.expo/packager-info.json
@@ -3,7 +3,7 @@
   "expoServerPort": null,
   "packagerPort": null,
   "packagerPid": null,
-  "expoServerNgrokUrl": "https://bc-wiq.anonymous.neighbor-corps-react-native.exp.direct",
-  "packagerNgrokUrl": "https://packager.bc-wiq.anonymous.neighbor-corps-react-native.exp.direct",
-  "ngrokPid": 99720
+  "expoServerNgrokUrl": "https://6p-zun.anonymous.neighbor-corps-react-native.exp.direct",
+  "packagerNgrokUrl": "https://packager.6p-zun.anonymous.neighbor-corps-react-native.exp.direct",
+  "ngrokPid": 17708
 }

--- a/.expo/settings.json
+++ b/.expo/settings.json
@@ -3,5 +3,5 @@
   "lanType": "ip",
   "dev": true,
   "minify": false,
-  "urlRandomness": "bc-wiq"
+  "urlRandomness": "6p-zun"
 }

--- a/screens/CreateTaskScreen.js
+++ b/screens/CreateTaskScreen.js
@@ -65,12 +65,9 @@ export default class CreateTaskScreen extends Component {
 
   _createTask = async (event) => {
 
-    this.props.navigation.navigate('Home')
-
     event.preventDefault();
     var value = this.refs.form.getValue();
     
-
     if (value) {
 
       this.setState({
@@ -84,10 +81,14 @@ export default class CreateTaskScreen extends Component {
         position: JSON.parse(this.props.navigation.state.params.getTaskLocation),
         postedBy: this.state.postedBy
 
-      })
-        .catch(err => console.log(err));
+      }).catch(err => console.log(err));
+      
       console.log("I'm called ")
       console.log(this.state);
+      
+      // In tcomb-form-native, if validation fails, value will be null.
+      // Navigate to target screen after validation from tcomb, or else validation fails but the screen still navigates resulting in null data being created. 
+      this.props.navigation.navigate('Home');
     }
     else {
       disabled = this.state.validity

--- a/screens/TasksScreen.js
+++ b/screens/TasksScreen.js
@@ -61,11 +61,34 @@ export default class Tasks extends Component {
     isLoading: true,
   };
 
+  // This is to solve the issue where taskscreen needed to be refreshed everytime a new task is created or when there is a change in the task's state
+  // React Navigation mounted the component the first visit, and it remains mounted at that screen even after user navigate to another screen
+  // https://reactnavigation.org/docs/en/navigation-prop.html#addlistener-subscribe-to-updates-to-navigation-lifecycle
+  // addListener - Subscribe to updates to navigation lifecycle
+  // React Navigation emits events to screen components that subscribe to them:
+  // didFocus - the screen focused (if there was a transition, the transition completed)
+  // In this case, run this.loadTasks() only after the Task View screen is focused.
+  // Everytime user goes to Task View screen, the screen will have all task loaded.
+  didFocusSubscription = this.props.navigation.addListener(
+    'didFocus',
+    () => {
+      console.log("********* didFocus - TasksScreen *********");
+      this.loadTasks();
+    }
+  )
+
   // When the component mounts, load all Tasks and save them to this.state.Tasks
   componentDidMount() {
     this.loadTasks();
     console.log(this.state.tasks);
   }
+
+  // Remove the didFocusSubscription listener before the component is unmounted
+  componentWillUnmount() {
+    didFocusSubscription.remove();
+  }
+
+
 
   constructor(props) {
     super(props);


### PR DESCRIPTION
* added event listener to tasks view screen to load the tasks whenever user visits the screen, without having to reload/refresh the page multiple times
* Reference: https://reactnavigation.org/docs/en/navigation-prop.html#addlistener-subscribe-to-updates-to-navigation-lifecycle
* modified create task screen to allow tcomb-form-native validation before page navigation